### PR TITLE
Feature/idp 571 populate topic field

### DIFF
--- a/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
+++ b/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
@@ -1,13 +1,16 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using EventGridEmulator.Configuration;
+using EventGridEmulator.Network;
 
 namespace EventGridEmulator.Tests;
 
 public class EmulatorValidationTests
 {
     private readonly ITestOutputHelper _testOutputHelper;
+    private readonly string ExpectedTopic = "orders";
 
     public EmulatorValidationTests(ITestOutputHelper testOutputHelper)
     {
@@ -15,15 +18,15 @@ public class EmulatorValidationTests
     }
 
     [Fact]
-    public async Task ValidatePublishAndSubscribeRoundTrip()
+    public async Task ValidatePublishAndSubscribeRoundTripForEventGridEvent()
     {
         // Define the handler to intercept the message
-        string message = string.Empty;
+        var message = string.Empty;
         HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
 
         // Create the EventGrid subscriber
         using var subscriber = new FactoryClientBuilder(handler)
-            .WithTopic("orders", "https://localhost/orders-webhook")
+            .WithTopic(this.ExpectedTopic, "https://localhost/orders-webhook")
             .Build();
 
         // Create the EventGrid publisher
@@ -45,7 +48,41 @@ public class EmulatorValidationTests
         // Assert that the message was successfully received
         var @event = JsonSerializer.Deserialize<JsonObject[]>(message) ?? throw new NullReferenceException("Message cannot be deserialized");
         var result = @event.Single()["data"].Deserialize<DataModel>();
+        var receivedTopic = @event.Single()["topic"].Deserialize<string>();
         Assert.Equal("data", result?.Some);
+        Assert.Equal($"{SubscriberConstants.DefaultTopicValue}{this.ExpectedTopic}", receivedTopic);
+    }
+    
+    [Fact]
+    public async Task ValidatePublishAndSubscribeRoundTripForCloudEvent()
+    {
+        // Define the handler to intercept the message
+        var message = string.Empty;
+        HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
+
+        // Create the EventGrid subscriber
+        using var subscriber = new FactoryClientBuilder(handler)
+            .WithTopic(this.ExpectedTopic, "https://localhost/orders-webhook")
+            .Build();
+
+        // Create the EventGrid publisher
+        var publisher = new PublisherBuilder(subscriber)
+            .WithEndpoint(new Uri("https://localhost/orders/api/events"))
+            .Build();
+
+        // Create and send an event to EventGrid
+        var cloudEvent = new CloudEvent("foo", "bar", new DataModel(some: "data"));
+        var response = await publisher.SendEventAsync(cloudEvent);
+        
+        // Assert that the message was successfully sent
+        Assert.Equal(200, response.Status);
+
+        // Assert that the message was successfully received
+        var @event = JsonSerializer.Deserialize<JsonObject[]>(message) ?? throw new NullReferenceException("Message cannot be deserialized");
+        var result = @event.Single()["data"].Deserialize<DataModel>();
+        var receivedTopic = @event.Single()["source"].Deserialize<string>();
+        Assert.Equal("data", result?.Some);
+        Assert.Equal($"{SubscriberConstants.DefaultTopicValue}{this.ExpectedTopic}", receivedTopic);
     }
 
     private class DataModel

--- a/src/EventGridEmulator/EventHandling/BaseEventHttpContextHandler.cs
+++ b/src/EventGridEmulator/EventHandling/BaseEventHttpContextHandler.cs
@@ -4,14 +4,14 @@ using Microsoft.Extensions.Options;
 
 namespace EventGridEmulator.EventHandling;
 
-internal abstract class BaseEventHttpContextHander<TEvent>
+internal abstract class BaseEventHttpContextHandler<TEvent>
 {
     private readonly HttpClient _httpClient;
     private readonly ISubscriberCancellationTokenRegistry _cancellationTokenRegistry;
     private readonly IOptionsMonitor<TopicOptions> _options;
     private readonly ILogger _logger;
 
-    protected BaseEventHttpContextHander(
+    protected BaseEventHttpContextHandler(
         IHttpClientFactory httpClientFactory,
         ISubscriberCancellationTokenRegistry cancellationTokenRegistry,
         IOptionsMonitor<TopicOptions> options,
@@ -45,6 +45,7 @@ internal abstract class BaseEventHttpContextHander<TEvent>
         foreach (var subscriber in subscribers)
         {
             var cancellationToken = this._cancellationTokenRegistry.Get(topic, subscriber);
+            this.EnhanceEventData(events, topic);
             _ = this.SendEventsToSubscriberFireAndForget(topic, subscriber, events, cancellationToken);
         }
 
@@ -76,5 +77,9 @@ internal abstract class BaseEventHttpContextHander<TEvent>
         {
             info.LogRequestFailed(this._logger, ex);
         }
+    }
+    
+    protected virtual void EnhanceEventData(IEnumerable<TEvent> events, string topicName)
+    {
     }
 }

--- a/src/EventGridEmulator/EventHandling/CloudEventHttpContextHandler.cs
+++ b/src/EventGridEmulator/EventHandling/CloudEventHttpContextHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace EventGridEmulator.EventHandling;
 
-internal sealed class CloudEventHttpContextHandler : BaseEventHttpContextHander<CloudEvent>, ICloudEventHttpContextHandler
+internal sealed class CloudEventHttpContextHandler : BaseEventHttpContextHandler<CloudEvent>, ICloudEventHttpContextHandler
 {
     public CloudEventHttpContextHandler(
         IHttpClientFactory httpClientFactory,
@@ -14,5 +14,13 @@ internal sealed class CloudEventHttpContextHandler : BaseEventHttpContextHander<
         ILogger<CloudEventHttpContextHandler> logger)
         : base(httpClientFactory, cancellationTokenRegistry, options, logger)
     {
+    }
+
+    protected override void EnhanceEventData(IEnumerable<CloudEvent> cloudEvents, string topicName)
+    {
+        foreach (var @event in cloudEvents)
+        {
+            @event.Source = $"{SubscriberConstants.DefaultTopicValue}/{topicName}";
+        }
     }
 }

--- a/src/EventGridEmulator/EventHandling/CloudEventHttpContextHandler.cs
+++ b/src/EventGridEmulator/EventHandling/CloudEventHttpContextHandler.cs
@@ -20,7 +20,7 @@ internal sealed class CloudEventHttpContextHandler : BaseEventHttpContextHandler
     {
         foreach (var @event in cloudEvents)
         {
-            @event.Source = $"{SubscriberConstants.DefaultTopicValue}/{topicName}";
+            @event.Source = $"{SubscriberConstants.DefaultTopicValue}{topicName}";
         }
     }
 }

--- a/src/EventGridEmulator/EventHandling/EventGridEventHttpContextHandler.cs
+++ b/src/EventGridEmulator/EventHandling/EventGridEventHttpContextHandler.cs
@@ -20,7 +20,7 @@ internal sealed class EventGridEventHttpContextHandler : BaseEventHttpContextHan
     {
         foreach (var @event in eventGridEvents)
         {
-            @event.Topic = $"{SubscriberConstants.DefaultTopicValue}/{topicName}";
+            @event.Topic = $"{SubscriberConstants.DefaultTopicValue}{topicName}";
         }
     }
 }

--- a/src/EventGridEmulator/EventHandling/EventGridEventHttpContextHandler.cs
+++ b/src/EventGridEmulator/EventHandling/EventGridEventHttpContextHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace EventGridEmulator.EventHandling;
 
-internal sealed class EventGridEventHttpContextHandler : BaseEventHttpContextHander<EventGridEvent>, IEventGridEventHttpContextHandler
+internal sealed class EventGridEventHttpContextHandler : BaseEventHttpContextHandler<EventGridEvent>, IEventGridEventHttpContextHandler
 {
     public EventGridEventHttpContextHandler(
         IHttpClientFactory httpClientFactory,
@@ -14,5 +14,13 @@ internal sealed class EventGridEventHttpContextHandler : BaseEventHttpContextHan
         ILogger<EventGridEventHttpContextHandler> logger)
         : base(httpClientFactory, cancellationTokenRegistry, options, logger)
     {
+    }
+
+    protected override void EnhanceEventData(IEnumerable<EventGridEvent> eventGridEvents, string topicName)
+    {
+        foreach (var @event in eventGridEvents)
+        {
+            @event.Topic = $"{SubscriberConstants.DefaultTopicValue}/{topicName}";
+        }
     }
 }

--- a/src/EventGridEmulator/Network/SubscriberConstants.cs
+++ b/src/EventGridEmulator/Network/SubscriberConstants.cs
@@ -5,6 +5,8 @@ namespace EventGridEmulator.Network;
 internal static class SubscriberConstants
 {
     public const string HttpClientName = "subscribers";
+    
+    public const string DefaultTopicValue = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.EventGrid/topics";
 
     public static readonly HashSet<HttpStatusCode> NonRetriableStatusCodes = new HashSet<HttpStatusCode>
     {

--- a/src/EventGridEmulator/Network/SubscriberConstants.cs
+++ b/src/EventGridEmulator/Network/SubscriberConstants.cs
@@ -6,7 +6,7 @@ internal static class SubscriberConstants
 {
     public const string HttpClientName = "subscribers";
     
-    public const string DefaultTopicValue = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.EventGrid/topics";
+    public const string DefaultTopicValue = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.EventGrid/topics/";
 
     public static readonly HashSet<HttpStatusCode> NonRetriableStatusCodes = new HashSet<HttpStatusCode>
     {


### PR DESCRIPTION
As a developer, I want to enhance EventGrid Emulator events similar to the “real” Azure Event Grid where topic take care of setting this `EventGridEvent.Topic` / `CloudEvent.Source` when pushing the events to subscribers.

COS:
- The emulator sets the Topic property before publishing the events to the subscribers
 - Because there’s no real Azure resource here, we can probably generate a fake topic string like this one:/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/event-grid-emulator/providers/Microsoft.EventGrid/topics/{topicName} where {topicName} comes from the emulator documentation.
- Cloud events : Updated `Source` property with topic location