### PR TITLE
Remove comments in the renovate file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,6 @@
       "groupName": "NuGet dependencies"
     },    
     {
-      // We rely on specific preview version of Azure.Messaging.EventGrid for Pull Delivery
       "matchManagers": ["nuget"],
       "matchPackageNames": ["NuGet Azure.Messaging.EventGrid"],
       "groupName": "NuGet Azure.Messaging.EventGrid"


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes

Fix https://github.com/gsoft-inc/wl-eventgrid-emulator/issues/48

````
INFO: Repository has invalid config (repository=gsoft-inc/wl-eventgrid-emulator)
       "error": {
         "validationSource": "renovate.json",
         "validationError": "Invalid JSON (parsing failed)",
         "validationMessage": "Syntax error: expecting String near      // We",
         "message": "config-validation",
         "stack": "Error: config-validation\n    at checkForRepoConfigError (/home/runner/.npm/_npx/05eeecd92f4e18e0/node_modules/renovate/lib/workers/repository/init/merge.ts:158:17)\n    at mergeRenovateConfig (/home/runner/.npm/_npx/05eeecd92f4e18e0/node_modules/renovate/lib/workers/repository/init/merge.ts:182:3)\n    at getRepoConfig (/home/runner/.npm/_npx/05eeecd92f4e18e0/node_modules/renovate/lib/workers/repository/init/config.ts:14:12)\n    at initRepo (/home/runner/.npm/_npx/05eeecd92f4e18e0/node_modules/renovate/lib/workers/repository/init/index.ts:55:12)\n    at Object.renovateRepository (/home/runner/.npm/_npx/05eeecd92f4e18e0/node_modules/renovate/lib/workers/repository/index.ts:62:14)\n    at attributes.repository (/home/runner/.npm/_npx/05eeecd92f4e18e0/node_modules/renovate/lib/workers/global/index.ts:217:11)\n    at start (/home/runner/.npm/_npx/05eeecd92f4e18e0/node_modules/renovate/lib/workers/global/index.ts:202:7)\n    at /home/runner/.npm/_npx/05eeecd92f4e18e0/node_modules/renovate/lib/renovate.ts:18:22"
       }
````
