### PR TITLE
[IDP-2744] Fix auto-merge and nuget conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - "renovate/**"
 
+# Prevent duplicate runs if Renovate falls back to creating a PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description of changes

- Setup concurrency option to prevent duplicate run when Renovate falls back to creating a PR
