### PR TITLE
Add 202 to NonRetriableStatusCodes to support Event Grid Trigger Function

### DIFF
--- a/src/EventGridEmulator/Network/SubscriberConstants.cs
+++ b/src/EventGridEmulator/Network/SubscriberConstants.cs
@@ -8,19 +8,23 @@ internal static class SubscriberConstants
 
     public const string DefaultTopicValue = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.EventGrid/topics/";
 
+    // Message Delivery Status
+    // https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry?WT.mc_id=DT-MVP-5003978#message-delivery-status
     public static readonly HashSet<HttpStatusCode> NonRetriableStatusCodes = new HashSet<HttpStatusCode>
-    {
-        // Of course we let HTTP 200 pass through
+    {      
+        // Success Codes
         HttpStatusCode.OK,
-
-        // HTTP 202 is returned by Event Grid Trigger and cannot force a different status code.
+        HttpStatusCode.Created,
         HttpStatusCode.Accepted,
+        HttpStatusCode.NonAuthoritativeInformation,
+        HttpStatusCode.NoContent,
+        HttpStatusCode.Forbidden,
 
-        // Those cannot be retried based on Event Grid's documentation
-        // https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry#retry-schedule
+        // Failure Codes
         HttpStatusCode.BadRequest,
-        HttpStatusCode.RequestEntityTooLarge,
         HttpStatusCode.Unauthorized,
+        HttpStatusCode.Forbidden,
+        HttpStatusCode.RequestEntityTooLarge
     };
 
     // Event Grid retry schedule

--- a/src/EventGridEmulator/Network/SubscriberConstants.cs
+++ b/src/EventGridEmulator/Network/SubscriberConstants.cs
@@ -11,14 +11,13 @@ internal static class SubscriberConstants
     // Message Delivery Status
     // https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry?WT.mc_id=DT-MVP-5003978#message-delivery-status
     public static readonly HashSet<HttpStatusCode> NonRetriableStatusCodes = new HashSet<HttpStatusCode>
-    {      
+    {
         // Success Codes
         HttpStatusCode.OK,
         HttpStatusCode.Created,
         HttpStatusCode.Accepted,
         HttpStatusCode.NonAuthoritativeInformation,
         HttpStatusCode.NoContent,
-        HttpStatusCode.Forbidden,
 
         // Failure Codes
         HttpStatusCode.BadRequest,

--- a/src/EventGridEmulator/Network/SubscriberConstants.cs
+++ b/src/EventGridEmulator/Network/SubscriberConstants.cs
@@ -13,6 +13,9 @@ internal static class SubscriberConstants
         // Of course we let HTTP 200 pass through
         HttpStatusCode.OK,
 
+        // HTTP 202 is returned by Event Grid Trigger and cannot force a different status code.
+        HttpStatusCode.Accepted,
+
         // Those cannot be retried based on Event Grid's documentation
         // https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry#retry-schedule
         HttpStatusCode.BadRequest,


### PR DESCRIPTION
## Description of changes
- Added `HttpStatusCode.Accepted` (202) to the `NonRetriableStatusCodes` to support the return response of an Event Grid Trigger function.

## Breaking changes
- None.
