### PR TITLE
fix: preserve original source for cloud event messages

### DIFF
--- a/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
+++ b/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
@@ -41,13 +41,13 @@ public class EmulatorValidationTests
         // Assert that the message was successfully received
         var @event = JsonSerializer.Deserialize<JsonObject[]>(message) ?? throw new NullReferenceException("Message cannot be deserialized");
         var result = @event.Single()["data"].Deserialize<DataModel>();
-        var receivedTopic = @event.Single()["topic"].Deserialize<string>();
+        var receivedSource = @event.Single()["topic"].Deserialize<string>();
         Assert.Equal("data", result?.Some);
-        Assert.Equal($"{SubscriberConstants.DefaultTopicValue}{ExpectedTopic}", receivedTopic);
+        Assert.Equal($"{SubscriberConstants.DefaultTopicValue}{ExpectedTopic}", receivedSource);
     }
 
     [Fact]
-    public async Task ValidatePublishAndSubscribeRoundTripForCloudEvent()
+    public async Task ValidatePublishAndSubscribeRoundTripForCloudEventWithEmptySource()
     {
         // Define the handler to intercept the message
         var message = string.Empty;
@@ -64,7 +64,7 @@ public class EmulatorValidationTests
             .Build();
 
         // Create and send an event to EventGrid
-        var cloudEvent = new CloudEvent("foo", "bar", new DataModel(some: "data"));
+        var cloudEvent = new CloudEvent("", "bar", new DataModel(some: "data"));
         var response = await publisher.SendEventAsync(cloudEvent);
 
         // Assert that the message was successfully sent
@@ -73,9 +73,42 @@ public class EmulatorValidationTests
         // Assert that the message was successfully received
         var @event = JsonSerializer.Deserialize<JsonObject[]>(message) ?? throw new NullReferenceException("Message cannot be deserialized");
         var result = @event.Single()["data"].Deserialize<DataModel>();
-        var receivedTopic = @event.Single()["source"].Deserialize<string>();
+        var receivedSource = @event.Single()["source"].Deserialize<string>();
         Assert.Equal("data", result?.Some);
-        Assert.Equal($"{SubscriberConstants.DefaultTopicValue}{ExpectedTopic}", receivedTopic);
+        Assert.Equal($"{SubscriberConstants.DefaultTopicValue}{ExpectedTopic}", receivedSource);
+    }
+
+    [Fact]
+    public async Task ValidatePublishAndSubscribeRoundTripForCloudEventPreserveOriginalSource()
+    {
+        // Define the handler to intercept the message
+        var message = string.Empty;
+        var originalSource = "SOME_SOURCE_VALUE";
+        HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
+
+        // Create the EventGrid subscriber
+        using var subscriber = new FactoryClientBuilder(handler)
+            .WithTopic(ExpectedTopic, "https://localhost/orders-webhook")
+            .Build();
+
+        // Create the EventGrid publisher
+        var publisher = new PublisherBuilder(subscriber)
+            .WithEndpoint(new Uri("https://localhost/orders/api/events"))
+            .Build();
+
+        // Create and send an event to EventGrid
+        var cloudEvent = new CloudEvent(originalSource, "bar", new DataModel(some: "data"));
+        var response = await publisher.SendEventAsync(cloudEvent);
+
+        // Assert that the message was successfully sent
+        Assert.Equal(200, response.Status);
+
+        // Assert that the message was successfully received
+        var @event = JsonSerializer.Deserialize<JsonObject[]>(message) ?? throw new NullReferenceException("Message cannot be deserialized");
+        var result = @event.Single()["data"].Deserialize<DataModel>();
+        var receivedSource = @event.Single()["source"].Deserialize<string>();
+        Assert.Equal("data", result?.Some);
+        Assert.Equal(originalSource, receivedSource);
     }
 
     private sealed class DataModel

--- a/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
+++ b/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
@@ -41,9 +41,9 @@ public class EmulatorValidationTests
         // Assert that the message was successfully received
         var @event = JsonSerializer.Deserialize<JsonObject[]>(message) ?? throw new NullReferenceException("Message cannot be deserialized");
         var result = @event.Single()["data"].Deserialize<DataModel>();
-        var receivedSource = @event.Single()["topic"].Deserialize<string>();
+        var receivedTopic = @event.Single()["topic"].Deserialize<string>();
         Assert.Equal("data", result?.Some);
-        Assert.Equal($"{SubscriberConstants.DefaultTopicValue}{ExpectedTopic}", receivedSource);
+        Assert.Equal($"{SubscriberConstants.DefaultTopicValue}{ExpectedTopic}", receivedTopic);
     }
 
     [Fact]

--- a/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
+++ b/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
@@ -15,7 +15,7 @@ public class EmulatorValidationTests
     {
         // Define the handler to intercept the message
         var message = string.Empty;
-        HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
+        using HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
 
         // Create the EventGrid subscriber
         using var subscriber = new FactoryClientBuilder(handler)
@@ -51,7 +51,7 @@ public class EmulatorValidationTests
     {
         // Define the handler to intercept the message
         var message = string.Empty;
-        HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
+        using HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
 
         // Create the EventGrid subscriber
         using var subscriber = new FactoryClientBuilder(handler)

--- a/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
+++ b/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
@@ -84,7 +84,7 @@ public class EmulatorValidationTests
         // Define the handler to intercept the message
         var message = string.Empty;
         var originalSource = "SOME_SOURCE_VALUE";
-        HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
+        using HttpMessageHandler handler = new TestHandler(requestAction => message = requestAction);
 
         // Create the EventGrid subscriber
         using var subscriber = new FactoryClientBuilder(handler)

--- a/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
+++ b/src/EventGridEmulator.Tests/EmulatorValidationTests.cs
@@ -63,7 +63,7 @@ public class EmulatorValidationTests
             .WithEndpoint(new Uri("https://localhost/orders/api/events"))
             .Build();
 
-        // Create and send an event to EventGrid
+        // Create and send an event to EventGrid with an empty source
         var cloudEvent = new CloudEvent("", "bar", new DataModel(some: "data"));
         var response = await publisher.SendEventAsync(cloudEvent);
 
@@ -96,7 +96,7 @@ public class EmulatorValidationTests
             .WithEndpoint(new Uri("https://localhost/orders/api/events"))
             .Build();
 
-        // Create and send an event to EventGrid
+        // Create and send an event to EventGrid with a source
         var cloudEvent = new CloudEvent(originalSource, "bar", new DataModel(some: "data"));
         var response = await publisher.SendEventAsync(cloudEvent);
 

--- a/src/EventGridEmulator/EventHandling/CloudEventHttpContextHandler.cs
+++ b/src/EventGridEmulator/EventHandling/CloudEventHttpContextHandler.cs
@@ -19,9 +19,12 @@ internal sealed class CloudEventHttpContextHandler : BaseEventHttpContextHandler
 
     protected override void EnhanceEventData(IEnumerable<CloudEvent> cloudEvents, string topicName)
     {
-        // foreach (var @event in cloudEvents)
-        // {
-        //     @event.Source = $"{SubscriberConstants.DefaultTopicValue}{topicName}";
-        // }
+        foreach (var @event in cloudEvents)
+        {
+            if (string.IsNullOrEmpty(@event.Source))
+            {
+                @event.Source = $"{SubscriberConstants.DefaultTopicValue}{topicName}";
+            }
+        }
     }
 }

--- a/src/EventGridEmulator/EventHandling/CloudEventHttpContextHandler.cs
+++ b/src/EventGridEmulator/EventHandling/CloudEventHttpContextHandler.cs
@@ -19,9 +19,9 @@ internal sealed class CloudEventHttpContextHandler : BaseEventHttpContextHandler
 
     protected override void EnhanceEventData(IEnumerable<CloudEvent> cloudEvents, string topicName)
     {
-        foreach (var @event in cloudEvents)
-        {
-            @event.Source = $"{SubscriberConstants.DefaultTopicValue}{topicName}";
-        }
+        // foreach (var @event in cloudEvents)
+        // {
+        //     @event.Source = $"{SubscriberConstants.DefaultTopicValue}{topicName}";
+        // }
     }
 }


### PR DESCRIPTION
## Description of changes
Added a condition when overriding the source of the cloud event to preserve the original (how it works in Azure EG)
Added a test to confirm chnages


- [x] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
