### PR TITLE
fix(publish handler): add support for durable functions events content type

### DIFF
--- a/src/EventGridEmulator/EventHandling/EventGridPublishHandler.cs
+++ b/src/EventGridEmulator/EventHandling/EventGridPublishHandler.cs
@@ -14,6 +14,7 @@ internal sealed class EventGridPublishHandler
     private const string CloudEventContentType = "application/cloudevents+json; charset=utf-8";
     private const string CloudEventBatchContentType = "application/cloudevents-batch+json; charset=utf-8";
     private const string EventGridEventContentType = "application/json";
+    private const string EventGridEventWithCharsetContentType = "application/json; charset=utf-8";
 
     private readonly ILogger<EventGridPublishHandler> _logger;
     private readonly IEventGridEventHttpContextHandler _eventGridEventHttpContextHandler;
@@ -42,6 +43,7 @@ internal sealed class EventGridPublishHandler
         switch (context.Request.ContentType)
         {
             case EventGridEventContentType:
+            case EventGridEventWithCharsetContentType:
                 return this._eventGridEventHttpContextHandler.HandleAsync(context, topic);
 
             case CloudEventContentType:


### PR DESCRIPTION
## Description of changes
The Durable Functions framework, normally part of Azure Functions, can natively send lifecycle events to Event Grid. These are sent with `application/json; charset=utf-8`, which the emulator currently fails to handle.

This is a quick fix that adds the specific content type to the switch block. In future, it would probably be better to rework the switch/case to instead attempt to parse the incoming mimetype.